### PR TITLE
added check script functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-NAME = osixia/keepalived
-VERSION = 2.0.17
+NAME = moosebeandev/keepalived
+VERSION = 0.1.0
 
 .PHONY: build build-nocache test tag-latest push push-latest release git-tag-version
 

--- a/image/environment/default.yaml
+++ b/image/environment/default.yaml
@@ -17,6 +17,8 @@ KEEPALIVED_VIRTUAL_IPS:
 
 KEEPALIVED_NOTIFY: /container/service/keepalived/assets/notify.sh
 
+KEEPALIVED_CHECK: /container/service/keepalived/assets/check.sh
+
 KEEPALIVED_ROUTER_ID: 51
 
 KEEPALIVED_STATE: BACKUP

--- a/image/service/keepalived/assets/check.sh
+++ b/image/service/keepalived/assets/check.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+{{ KEEPALIVED_CHECK_SCRIPT }}

--- a/image/service/keepalived/assets/keepalived.conf
+++ b/image/service/keepalived/assets/keepalived.conf
@@ -2,6 +2,13 @@ global_defs {
   default_interface {{ KEEPALIVED_INTERFACE }}
 }
 
+vrrp_script chk_script {
+  script       {{ KEEPALIVED_CHECK }}
+  interval 2   # check every 2 seconds
+  fall 2       # require 2 failures for KO
+  rise 2       # require 2 successes for OK
+}
+
 vrrp_instance VI_1 {
   interface {{ KEEPALIVED_INTERFACE }}
 
@@ -24,4 +31,6 @@ vrrp_instance VI_1 {
   }
 
   {{ KEEPALIVED_NOTIFY }}
+  
+  {{ KEEPALIVED_CHECK_SCRIPT }}
 }

--- a/image/service/keepalived/startup.sh
+++ b/image/service/keepalived/startup.sh
@@ -16,12 +16,21 @@ if [ ! -e "$FIRST_START_DONE" ]; then
   sed -i "s|{{ KEEPALIVED_INTERFACE }}|$KEEPALIVED_INTERFACE|g" ${CONTAINER_SERVICE_DIR}/keepalived/assets/keepalived.conf
   sed -i "s|{{ KEEPALIVED_PRIORITY }}|$KEEPALIVED_PRIORITY|g" ${CONTAINER_SERVICE_DIR}/keepalived/assets/keepalived.conf
   sed -i "s|{{ KEEPALIVED_PASSWORD }}|$KEEPALIVED_PASSWORD|g" ${CONTAINER_SERVICE_DIR}/keepalived/assets/keepalived.conf
+  sed -i "s|{{ KEEPALIVED_CHECK }}|$KEEPALIVED_CHECK|g" ${CONTAINER_SERVICE_DIR}/keepalived/assets/keepalived.conf
 
   if [ -n "$KEEPALIVED_NOTIFY" ]; then
     sed -i "s|{{ KEEPALIVED_NOTIFY }}|notify \"$KEEPALIVED_NOTIFY\"|g" ${CONTAINER_SERVICE_DIR}/keepalived/assets/keepalived.conf
     chmod +x $KEEPALIVED_NOTIFY
   else
     sed -i "/{{ KEEPALIVED_NOTIFY }}/d" ${CONTAINER_SERVICE_DIR}/keepalived/assets/keepalived.conf
+  fi
+
+  if [ -n "$KEEPALIVED_CHECK_SCRIPT" ]; then
+    sed -i "s|{{ KEEPALIVED_CHECK_SCRIPT }}|track_script {\n    chk_script\n  }|g" ${CONTAINER_SERVICE_DIR}/keepalived/assets/keepalived.conf
+    sed -i "s+{{ KEEPALIVED_CHECK_SCRIPT }}+$KEEPALIVED_CHECK_SCRIPT+g" $KEEPALIVED_CHECK
+    chmod +x $KEEPALIVED_CHECK
+  else
+    sed -i "/{{ KEEPALIVED_CHECK_SCRIPT }}/d" ${CONTAINER_SERVICE_DIR}/keepalived/assets/keepalived.conf
   fi
 
   # unicast peers


### PR DESCRIPTION
Adding logic similar to KEEPALIVED_NOTIFY only for handling the check/tracking script functionality provided by keepalived.

https://tobru.ch/keepalived-check-and-notify-scripts/

The difference is KEEPALIVED_CHECK_SCRIPT expects a string command which will return 0 on a healthy check and something other than 0 for a failed check. This is in contrast to the notify script functionality built into the osixia image which expects the notify script to be mounted in a certain location and the environment var holds the path to the script. I wanted to be able to set the check script at runtime since most of the time it will be a relatively simple one liner to check something and return 0 if it is healthy.